### PR TITLE
Add default:true to the first author

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -44,6 +44,7 @@ export default defineAppConfig({
         {
             username: 'john-doe',
             name: 'John Doe',
+            default: true,
             description:
                 'lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.',
             avatar: '/images/avatar.jpg',


### PR DESCRIPTION
Hey I'm incredibly new to Nuxt so it's possible I made a mistake, so sorry if this PR is spam. But I got a 500 error when I cloned and ran this repo. Which was fixed when I added `default: true` to the first author in the list, which makes sense to me given [this line](https://github.com/bloggrify/bloggrify/blob/dc3e3f755042db0b8cf651896bb069d158ff6e60/composables/useAuthor.ts#L13) in `findAuthor`

![image](https://github.com/user-attachments/assets/5ebdeff4-7123-41ad-a8c3-7bf752a1d7f5)
